### PR TITLE
Exclude source folders and files unnecessary for deployment.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,4 +13,4 @@ markdown: kramdown
 highlighter: pygments
 permalink: pretty
 paginate: 5
-exclude: ["node_modules"]
+exclude: ["less","node_modules","Gruntfile.js","package.json","README.md"]


### PR DESCRIPTION
Exclude the "less" folder, and "Gruntfile.js", "package.json", and "README.md" files from being copied to the "_site" destination folder as they are unnecessary for deployment of the site.
