### PR TITLE
stop 404 page from showing in navigation bar

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -19,9 +19,11 @@
                     <a href="{{ site.baseurl }}/">Home</a>
                 </li>
                 {% for page in site.pages %}{% if page.title %}
+				{% if page.url != '/404.html' %}
                 <li>
                     <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
                 </li>
+				{% endif %}
                 {% endif %}{% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
Jekyll uses /404.html for a custom 404 page, so I modified the navigation bar to exclude it.