### PR TITLE
Add capability to optionally enable disqus comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ github_username:  davidtmiller
 facebook_username:  IronSummitMedia
 email_username:  your-email@yourdomain.com
 
+# Uncomment below line and add your disqus shortname for enabling disqus comments on every post
+# disqus_shortname: 
+
 # Build settings
 markdown: kramdown
 highlighter: rouge

--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -1,0 +1,12 @@
+{% if site.disqus_shortname %}    
+    <div id="disqus_thread"></div>
+    <script type="text/javascript">
+        var disqus_shortname = '{{ site.disqus_shortname }}';
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -44,6 +44,11 @@ layout: default
 
             </div>
         </div>
+        <div class="row">
+            <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+                {% include disqus.html %}
+            </div>
+        </div>
     </div>
 </article>
 


### PR DESCRIPTION
Users will be able to optionally enable disqus comments on every post by defining the `disqus_shortname` property in the config file.