### PR TITLE
Fixed theme name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ When installing the theme using RubyGems, demo images, posts, and pages are not 
 1. (Optional) Create a new Jekyll site: `jekyll new my-site`
 2. Replace the current theme in your `Gemfile` with `gem "jekyll-theme-clean-blog"`.
 3. Install the theme: `bundle install`
-4. Replace the current theme in your `_config.yml` file with `theme: jekyll-theme-awesome`.
+4. Replace the current theme in your `_config.yml` file with `theme: jekyll-theme-clean-blog`.
 5. Build your site: `bundle exec jekyll serve`
 
 Assuming there are no errors and the site is building properly, follow these steps next:


### PR DESCRIPTION
It looks like there was just a missed update or typo in the README. I couldn't get it to build with `jekyll-theme-awesome` but it seems to work just fine with `jekyll-theme-clean-blog`