### PR TITLE
Update navbar.html to use site.title instead of "Start Bootstrap"

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,7 +1,7 @@
 <!-- Navigation -->
 <nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">
   <div class="container">
-    <a class="navbar-brand" href="{{"/" | relative_url }}">Start Bootstrap</a>
+    <a class="navbar-brand" href="{{"/" | relative_url }}">{{ site.title | escape }}</a>
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
       Menu
       <i class="fa fa-bars"></i>


### PR DESCRIPTION
Use `site.title` in the header, so it's easily overridden by configuration

(n.b: the site.title set in _config.yml currently isn't "Start Bootstrap", so this patch will change the page header text to "Clean Blog".)