### PR TITLE
Optionally display a custom logo on the main page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -13,7 +13,11 @@ layout: default
       <div class="row">
         <div class="col-lg-8 col-md-10 mx-auto">
           <div class="page-heading">
-            <h1>{{ site.title }}</h1>
+            {% if site.logo %}
+                <img class="img-fluid" src="{{ site.logo }}" alt="{{ site.title }}" />
+            {% else %}
+                <h1>{{ site.title }}</h1>
+            {% endif %}
             {% if site.description %}
               <span class="subheading">{{ site.description }}</span>
             {% endif %}


### PR DESCRIPTION
Display a custom logo on the main page instead of text is a parameter "logo" is provided in _config.yml

Example:

```yaml
# Site settings
# ...
title: "My Blog"
logo: "static/img/logo.png"
email: me@myblog.com
```