### PR TITLE
Mirgration gulp(v3.0 -> v4.0)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,20 +1,74 @@
+// var gulp = require('gulp');
+
+// gulp.task('copy', function() {
+
+//   // Start Bootstrap Clean Blog SCSS
+//   gulp.src(['node_modules/startbootstrap-clean-blog/scss/**/*'])
+//     .pipe(gulp.dest('assets/vendor/startbootstrap-clean-blog/scss'))
+
+//   // Start Bootstrap Clean Blog JS
+//   gulp.src([
+//       'node_modules/startbootstrap-clean-blog/js/clean-blog.min.js',
+//       'node_modules/startbootstrap-clean-blog/js/jqBootstrapValidation.js'
+//     ])
+//     .pipe(gulp.dest('assets/vendor/startbootstrap-clean-blog/js'))
+
+//   // Bootstrap
+//   gulp.src([
+//       'node_modules/bootstrap/dist/**/*',
+//       '!**/npm.js',
+//       '!**/bootstrap-theme.*',
+//       '!**/*.map'
+//     ])
+//     .pipe(gulp.dest('assets/vendor/bootstrap'))
+
+//   // jQuery
+//   gulp.src(['node_modules/jquery/dist/jquery.js', 'node_modules/jquery/dist/jquery.min.js'])
+//     .pipe(gulp.dest('assets/vendor/jquery'))
+
+//   // Font Awesome
+//   gulp.src([
+//       'node_modules/font-awesome/**',
+//       '!node_modules/font-awesome/**/*.map',
+//       '!node_modules/font-awesome/.npmignore',
+//       '!node_modules/font-awesome/*.txt',
+//       '!node_modules/font-awesome/*.md',
+//       '!node_modules/font-awesome/*.json'
+//     ])
+//     .pipe(gulp.dest('assets/vendor/font-awesome'))
+
+// })
+
+// // Default task
+// gulp.task('default', ['copy']);
+
+
+//if you use gulp v4.0, need to migration this code v3.0 -> v4.0
+//https://github.com/gulpjs/gulp/blob/master/docs/recipes/using-multiple-sources-in-one-task.md
+
+
+//⭐️ 
+//npm install --save-dev gulp@next merge-stream
 var gulp = require('gulp');
+
+//⭐️
+var merge = require('merge-stream');
 
 gulp.task('copy', function() {
 
   // Start Bootstrap Clean Blog SCSS
-  gulp.src(['node_modules/startbootstrap-clean-blog/scss/**/*'])
+  var bootstrapSCSS = gulp.src(['node_modules/startbootstrap-clean-blog/scss/**/*'])
     .pipe(gulp.dest('assets/vendor/startbootstrap-clean-blog/scss'))
 
   // Start Bootstrap Clean Blog JS
-  gulp.src([
+  var bootstrapJS = gulp.src([
       'node_modules/startbootstrap-clean-blog/js/clean-blog.min.js',
       'node_modules/startbootstrap-clean-blog/js/jqBootstrapValidation.js'
     ])
     .pipe(gulp.dest('assets/vendor/startbootstrap-clean-blog/js'))
 
   // Bootstrap
-  gulp.src([
+  var bootstrap = gulp.src([
       'node_modules/bootstrap/dist/**/*',
       '!**/npm.js',
       '!**/bootstrap-theme.*',
@@ -23,11 +77,11 @@ gulp.task('copy', function() {
     .pipe(gulp.dest('assets/vendor/bootstrap'))
 
   // jQuery
-  gulp.src(['node_modules/jquery/dist/jquery.js', 'node_modules/jquery/dist/jquery.min.js'])
+  var jQuery = gulp.src(['node_modules/jquery/dist/jquery.js', 'node_modules/jquery/dist/jquery.min.js'])
     .pipe(gulp.dest('assets/vendor/jquery'))
 
   // Font Awesome
-  gulp.src([
+  var fontAwesome = gulp.src([
       'node_modules/font-awesome/**',
       '!node_modules/font-awesome/**/*.map',
       '!node_modules/font-awesome/.npmignore',
@@ -37,7 +91,8 @@ gulp.task('copy', function() {
     ])
     .pipe(gulp.dest('assets/vendor/font-awesome'))
 
-})
+  return merge(bootstrapSCSS, bootstrapJS, bootstrap, jQuery, fontAwesome);
+});
 
 // Default task
-gulp.task('default', ['copy']);
+gulp.task('default', gulp.series(['copy']));


### PR DESCRIPTION
If you use gulp 4.0, you need to migration `gulpfile.js`.
Current `gulpfile.js` version is 3.0, so need to migration 