### PR TITLE
fix setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ When installing the theme using RubyGems, demo images, posts, and pages are not 
 1. (Optional) Create a new Jekyll site: `jekyll new my-site`
 2. Replace the current theme in your `Gemfile` with `gem "jekyll-theme-clean-blog"`.
 3. Install the theme: `bundle install`
-4. Replace the current theme in your `_config.yml` file with `theme: jekyll-theme-awesome`.
+4. Replace the current theme in your `_config.yml` file with `theme: jekyll-theme-clean-blog`.
 5. Build your site: `bundle exec jekyll serve`
 
 Assuming there are no errors and the site is building properly, follow these steps next:


### PR DESCRIPTION
Just fixed step 4, as setting the theme in `_config.yml` to `jekyll-theme-awesome` resulted in the following error when trying to build the site:

`jekyll 3.8.3 | Error:  The jekyll-theme-awesome theme could not be found.`

Setting the theme in `_config.yml` to `jekyll-theme-clean-blog` let me build the site succesfully.