### PR TITLE
Add Medium Style Reading Time Indicator on Posts

### DIFF
--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,0 +1,3 @@
+<span class="reading-time" title="Estimated read time">
+    {% assign words = include.content | number_of_words %}
+    {% if words < 270 %} {{ words }} 1 min {% else %} {{ words | divided_by:135 }} mins {% endif %} read </span>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,9 +4,9 @@ layout: default
 
 <!-- Page Header -->
 {% if page.background %}
-  <header class="masthead" style="background-image: url('{{ page.background | prepend: site.baseurl | replace: '//', '/' }}')">
+<header class="masthead" style="background-image: url('{{ page.background | prepend: site.baseurl | replace: '//', '/' }}')">
   {% else %}
-    <header class="masthead">
+  <header class="masthead">
     {% endif %}
     <div class="overlay"></div>
     <div class="container">
@@ -15,7 +15,7 @@ layout: default
           <div class="page-heading">
             <h1>{{ site.title }}</h1>
             {% if site.description %}
-              <span class="subheading">{{ site.description }}</span>
+            <span class="subheading">{{ site.description }}</span>
             {% endif %}
           </div>
         </div>
@@ -32,26 +32,26 @@ layout: default
         <!-- Home Post List -->
         {% for post in site.posts limit : 5 %}
 
-          <article class="post-preview">
-            <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
-              <h2 class="post-title">{{ post.title }}</h2>
-              {% if post.subtitle %}
-                <h3 class="post-subtitle">{{ post.subtitle }}</h3>
-              {% else %}
-                <h3 class="post-subtitle">{{ post.excerpt | strip_html | truncatewords: 15 }}</h3>
-              {% endif %}
-            </a>
-            <p class="post-meta">Posted by
-              {% if post.author %}
-                {{ post.author }}
-              {% else %}
-                {{ site.author }}
-              {% endif %}
-              on
-              {{ post.date | date: '%B %d, %Y' }}</p>
-          </article>
+        <article class="post-preview">
+          <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
+            <h2 class="post-title">{{ post.title }}</h2>
+            {% if post.subtitle %}
+            <h3 class="post-subtitle">{{ post.subtitle }}</h3>
+            {% else %}
+            <h3 class="post-subtitle">{{ post.excerpt | strip_html | truncatewords: 15 }}</h3>
+            {% endif %}
+          </a>
+          <p class="post-meta">Posted by
+            {% if post.author %}
+            {{ post.author }}
+            {% else %}
+            {{ site.author }}
+            {% endif %}
+            on
+            {{ post.date | date: '%B %d, %Y' }} &middot; {% include read_time.html content=post.content %}</p>
+        </article>
 
-          <hr>
+        <hr>
 
         {% endfor %}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,46 +5,51 @@ layout: default
 <!-- Page Header -->
 {% if page.background %}
 <header class="masthead" style="background-image: url('{{ page.background | prepend: site.baseurl | replace: '//', '/' }}')">
-{% else %}
-<header class="masthead">
-{% endif %}
-  <div class="overlay"></div>
-  <div class="container">
-    <div class="row">
-      <div class="col-lg-8 col-md-10 mx-auto">
-        <div class="post-heading">
-          <h1>{{ page.title }}</h1>
-          {% if page.subtitle %}
-          <h2 class="subheading">{{ page.subtitle }}</h2>
-          {% endif %}
-          <span class="meta">Posted by
-            <a href="#">Start Bootstrap</a>
-            on {{ page.date | date: '%B %d, %Y' }}</span>
+  {% else %}
+  <header class="masthead">
+    {% endif %}
+    <div class="overlay"></div>
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-8 col-md-10 mx-auto">
+          <div class="post-heading">
+            <h1>{{ page.title }}</h1>
+            {% if page.subtitle %}
+            <h2 class="subheading">{{ page.subtitle }}</h2>
+            {% endif %}
+            <span class="meta">Posted by
+              <a href="#">Start Bootstrap</a>
+              on {{ page.date | date: '%B %d, %Y' }} &middot; {% include read_time.html
+              content=page.content %}</span>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</header>
+  </header>
 
-<div class="container">
-  <div class="row">
-    <div class="col-lg-8 col-md-10 mx-auto">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-8 col-md-10 mx-auto">
 
-      {{ content }}
+        {{ content }}
 
-      <hr>
+        <hr>
 
-      <div class="clearfix">
+        <div class="clearfix">
 
-        {% if page.previous.url %}
-        <a class="btn btn-primary float-left" href="{{ page.previous.url | prepend: site.baseurl | replace: '//', '/' }}" data-toggle="tooltip" data-placement="top" title="{{ page.previous.title }}">&larr; Previous<span class="d-none d-md-inline"> Post</span></a>
-        {% endif %}
-        {% if page.next.url %}
-        <a class="btn btn-primary float-right" href="{{ page.next.url | prepend: site.baseurl | replace: '//', '/' }}" data-toggle="tooltip" data-placement="top" title="{{ page.next.title }}">Next<span class="d-none d-md-inline"> Post</span> &rarr;</a>
-        {% endif %}
+          {% if page.previous.url %}
+          <a class="btn btn-primary float-left" href="{{ page.previous.url | prepend: site.baseurl | replace: '//', '/' }}"
+            data-toggle="tooltip" data-placement="top" title="{{ page.previous.title }}">&larr; Previous<span class="d-none d-md-inline">
+              Post</span></a>
+          {% endif %}
+          {% if page.next.url %}
+          <a class="btn btn-primary float-right" href="{{ page.next.url | prepend: site.baseurl | replace: '//', '/' }}"
+            data-toggle="tooltip" data-placement="top" title="{{ page.next.title }}">Next<span class="d-none d-md-inline">
+              Post</span> &rarr;</a>
+          {% endif %}
+
+        </div>
 
       </div>
-
     </div>
   </div>
-</div>

--- a/posts/index.html
+++ b/posts/index.html
@@ -6,41 +6,43 @@ background: '/img/bg-post.jpg'
 
 {% for post in paginator.posts %}
 
-  <article class="post-preview">
-    <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
-      <h2 class="post-title">{{ post.title }}</h2>
-      {% if post.subtitle %}
-      <h3 class="post-subtitle">{{ post.subtitle }}</h3>
-      {% else %}
-      <h3 class="post-subtitle">{{ post.excerpt | strip_html | truncatewords: 15 }}</h3>
-      {% endif %}
-    </a>
-    <p class="post-meta">Posted by
-      {% if post.author %}
-        {{ post.author }}
-      {% else %}
-        {{ site.author }}
-      {% endif %}
-      on {{ post.date | date: '%B %d, %Y' }}</p>
-  </article>
+<article class="post-preview">
+  <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
+    <h2 class="post-title">{{ post.title }}</h2>
+    {% if post.subtitle %}
+    <h3 class="post-subtitle">{{ post.subtitle }}</h3>
+    {% else %}
+    <h3 class="post-subtitle">{{ post.excerpt | strip_html | truncatewords: 15 }}</h3>
+    {% endif %}
+  </a>
+  <p class="post-meta">Posted by
+    {% if post.author %}
+    {{ post.author }}
+    {% else %}
+    {{ site.author }}
+    {% endif %}
+    on {{ post.date | date: '%B %d, %Y' }} &middot; {% include read_time.html content=post.content %}</p>
+</article>
 
-  <hr>
+<hr>
 
 {% endfor %}
 
 <!-- Pager -->
 {% if paginator.total_pages > 1 %}
 
-  <div class="clearfix">
+<div class="clearfix">
 
-    {% if paginator.previous_page %}
-      <a class="btn btn-primary float-left" href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Newer<span class="d-none d-md-inline"> Posts</span></a>
-    {% endif %}
+  {% if paginator.previous_page %}
+  <a class="btn btn-primary float-left" href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr;
+    Newer<span class="d-none d-md-inline"> Posts</span></a>
+  {% endif %}
 
-    {% if paginator.next_page %}
-      <a class="btn btn-primary float-right" href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older<span class="d-none d-md-inline"> Posts</span> &rarr;</a>
-    {% endif %}
+  {% if paginator.next_page %}
+  <a class="btn btn-primary float-right" href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older<span
+      class="d-none d-md-inline"> Posts</span> &rarr;</a>
+  {% endif %}
 
-  </div>
+</div>
 
 {% endif %}


### PR DESCRIPTION
### What this does

Adds a reading time to blog posts on the home, posts and post pages.

### How to verify

After cloning the repo, run `bundle exec jekyll serve` and navigate to the home page, posts page or a specific post. 

You should see a reading time next to the post publish date.

### Screenshots
Below is a preview of the expected results. Notice the reading time next to the publish date.

<img width="770" alt="home-or-posts-view" src="https://user-images.githubusercontent.com/19945211/45603848-3205ab00-ba37-11e8-8462-605ea7bc236b.png">

<img width="1161" alt="post-view" src="https://user-images.githubusercontent.com/19945211/45603855-3b8f1300-ba37-11e8-9c7a-c357d06a7ac3.png">
