### PR TITLE
Add GitLab username to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -47,6 +47,16 @@
             </a>
           </li>
           {% endif %}
+          {% if site.gitlab_username %}
+          <li class="list-inline-item">
+            <a href="https://gitlab.com/{{ site.gitlab_username }}">
+              <span class="fa-stack fa-lg">
+                <i class="fas fa-circle fa-stack-2x"></i>
+                <i class="fab fa-gitlab fa-stack-1x fa-inverse"></i>
+              </span>
+            </a>
+          </li>
+          {% endif %}
         </ul>
         <p class="copyright text-muted">Copyright &copy; {{ site.author }} {{ 'now' | date: "%Y" }}</p>
       </div>


### PR DESCRIPTION
This PR adds the ability to add a GitLab username (with the appropriate icon) to the site's footer.