### PR TITLE
remove www from twitter links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,7 +9,7 @@
         <ul class="list-inline text-center">
           {% if site.twitter_username %}
           <li class="list-inline-item">
-            <a href="https://www.twitter.com/{{ site.twitter_username }}">
+            <a href="https://twitter.com/{{ site.twitter_username }}">
               <span class="fa-stack fa-lg">
                 <i class="fas fa-circle fa-stack-2x"></i>
                 <i class="fab fa-twitter fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
www not needed - saves a redirect