### PR TITLE
Remove extra number from 1 min read_time template

### DIFF
--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,3 +1,3 @@
 <span class="reading-time" title="Estimated read time">
   {% assign words = include.content | number_of_words %}
-  {% if words < 270 %} {{ words }} 1 min {% else %} {{ words | divided_by:135 }} mins {% endif %} read </span>
+  {% if words < 270 %} 1 min {% else %} {{ words | divided_by:135 }} mins {% endif %} read </span>


### PR DESCRIPTION
If post has fewer than 270 words, read time looks like "123 1 min read". This fixes it to be "1 min read".