### PR TITLE
Change Formspree URL dynamically

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -31,7 +31,7 @@
           $this = $("#sendMessageButton");
           $this.prop("disabled", true); // Disable submit button until AJAX call is complete to prevent duplicate messages
           $.ajax({
-            url: "//formspree.io/{{ site.email }}",
+            url: "{{ site.formspree }}",
             type: "POST",
             data: {
               name: name,


### PR DESCRIPTION
The change will allow configure the URL of a formspree form directly on the _config.yml.

The URL of the formspree default free form is diferent of the pattern defined here "//formspree.io/{{ site.email }}"