### PR TITLE
fix: Move google analytics script from body to head section

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,9 @@
 
 <html>
 
-{% include head.html %}
+  {% include google-analytics.html %}
+
+  {% include head.html %}
 
 <body>
 
@@ -13,8 +15,6 @@
   {% include footer.html %}
 
   {% include scripts.html %}
-
-  {% include google-analytics.html %}
 
 </body>
 


### PR DESCRIPTION
google analytics script tag should be located in head section.

ref: https://support.google.com/analytics/answer/1008080

> Paste it after the opening `<head>` tag on each page you want to measure.

It doesn't work if the script tag is located in body.
