### PR TITLE
Resolves #350

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,8 @@ linkedin_username:
 
 # Add your google-analytics ID here to activate google analytics
 google_analytics:   UA-XXXXXXXXX-X # out your google-analytics code
+# Opt out of tracking
+disable_tracking: false
 
 # Build settings
 markdown:           kramdown

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,9 +13,11 @@
   <meta property="og:description"
         content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
   <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ site.remote_url }}{{ site.baseurl }}{{ page.url }}">
   <meta property="og:title" content="{{page.title | normalize_whitespace | truncate: 50 | escape}}">
+
   {% if page.background && page.background != blank %}
-    <meta property="og:image" content="{{page.background | absolute_url}}"/>
+    <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}{{ page.background }}"/>
   {% endif %}
 
   <link href='https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,6 +10,14 @@
 
   <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
 
+  <meta property="og:description"
+        content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{{page.title | normalize_whitespace | truncate: 50 | escape}}">
+  {% if page.background && page.background != blank %}
+    <meta property="og:image" content="{{page.background | absolute_url}}"/>
+  {% endif %}
+
   <link href='https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
 
@@ -19,4 +27,7 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
 
+  {% if site.layouts contains 'overrides.styles' %}
+    {% include overrides.styles.html %}
+  {% endif %}
 </head>

--- a/_includes/overrides.styles.html
+++ b/_includes/overrides.styles.html
@@ -1,0 +1,3 @@
+<!-- Promise never to cause any merge conflicts in this file -->
+<!-- Put your stylesheet or styles here -->
+

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,9 @@
 
   {% include scripts.html %}
 
-  {% include google-analytics.html %}
+  {% unless site.disable_tracking %}
+    {% include google-analytics.html %}
+  {% endunless %}
 
 </body>
 


### PR DESCRIPTION
*Adds a way to add custom link tags.*

This is for adding style-sheets when we use the gem as a jekyll template. I had tried to make syntax highlighting work with rouge. But the style-sheets would just get messed up or not work. I put them under `(root_dir)/assets/css/base16.highlight.css`

*Allow users to disable ga tracking* 

Sometimes people would not want GA-tracking. So they can turn it off. By default its enabled. For backward compatibility

*Adds proper meta tags for opengraph*

This helps when people give a link to your website and they get a proper link preview with title description and image.



Thanks.